### PR TITLE
Use large pip dice always

### DIFF
--- a/multi_dice_roller.py
+++ b/multi_dice_roller.py
@@ -451,9 +451,8 @@ class DiceRollerApp(App[None]):
             )
 
         if not self.terminal_caps.get("emoji", True):
-            self.dice_emojis = ["1", "2", "3", "4", "5", "6"]
             self.notify(
-                "Emoji support not detected. Falling back to numbers.",
+                "Emoji support not detected. Dice summary may not render properly.",
                 severity="warning",
                 timeout=4,
             )


### PR DESCRIPTION
## Summary
- ensure dice grid uses large ASCII pip faces regardless of emoji support
- warn if emoji unsupported without altering dice faces

## Testing
- `python -m py_compile multi_dice_roller.py`

------
https://chatgpt.com/codex/tasks/task_e_68491e13ff208332938a5a530cdc37f9