### PR TITLE
Remove roll completion toast

### DIFF
--- a/multi_dice_roller.py
+++ b/multi_dice_roller.py
@@ -889,7 +889,6 @@ class DiceRollerApp(App[None]):
         if rolled_at_least_one:
             self.current_results = new_results_list
             self.app_roll_count += 1
-            self.notify(f"Roll #{self.app_roll_count} completed. Sum: {self.current_sum}", timeout=2)
         else:
             # This might happen if unlocked_indices was empty but the initial check failed,
             # or if all animations returned errors (though gather would likely raise one).


### PR DESCRIPTION
## Summary
- remove toast message after rolling dice

## Testing
- `python -m py_compile multi_dice_roller.py`

------
https://chatgpt.com/codex/tasks/task_e_6849212a4b648332a53b92e2f90e37dd