### PR TITLE
Fix CI ruff invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff pyright
       - name: Ruff
-        run: ruff .
+        run: ruff check .
       - name: Pyright
         run: pyright


### PR DESCRIPTION
## Summary
- fix ruff CLI usage in CI

## Testing
- `ruff check .`
- `pyright` *(fails: Import "textual.app" could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68492621f4948332a4121230b2136b2d