### PR TITLE
Fix invalid CSS property

### DIFF
--- a/multi_dice_roller.py
+++ b/multi_dice_roller.py
@@ -228,7 +228,7 @@ class DiceRollerApp(App[None]):
         content-align: center middle;
         text-align: center;
         line-height: 1;
-        font-family: monospace;
+        text-font: monospace;
         text-style: bold;
         background: $surface;
         border: solid $accent;


### PR DESCRIPTION
## Summary
- use `text-font` instead of the unsupported `font-family` property

## Testing
- `ruff check .`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_68493db74efc8332b662138fb9bcbb16